### PR TITLE
Fix undefined translation directory constant

### DIFF
--- a/includes/core/class-qcc-bootstrap.php
+++ b/includes/core/class-qcc-bootstrap.php
@@ -257,7 +257,8 @@ class QCC_Bootstrap {
         }
         
         // Fallback to plugin languages directory
-        $plugin_lang_dir = QCC_PLUGIN_DIR . '/languages/';
+        // Use plugin basename to build relative languages path for translations
+        $plugin_lang_dir = dirname(QCC_PLUGIN_BASENAME) . '/languages/';
         load_plugin_textdomain($domain, false, $plugin_lang_dir);
     }
     


### PR DESCRIPTION
## Summary
- fix fatal error by replacing undefined `QCC_PLUGIN_DIR` with a relative path using `dirname(QCC_PLUGIN_BASENAME)`

## Testing
- `php -l includes/core/class-qcc-bootstrap.php`


------
https://chatgpt.com/codex/tasks/task_e_68a433090a708331a0ab2062f0a90d11