### PR TITLE
Fix truncated validator class

### DIFF
--- a/includes/class-qcc-validator.php
+++ b/includes/class-qcc-validator.php
@@ -313,7 +313,9 @@ class QCC_Validator {
             )
         );
     }
-} input data
+
+    /**
+     * Validate input data
      */
     public static function validate_input($data) {
         self::$errors = array();
@@ -546,6 +548,5 @@ class QCC_Validator {
     public static function add_error($field, $message) {
         self::$errors[$field] = $message;
     }
-    
-    /**
-     * Validate
+}
+


### PR DESCRIPTION
## Summary
- repair malformed docblock and restore `validate_input` definition in validator
- remove stray comment and close `QCC_Validator` class properly

## Testing
- `php -l includes/class-qcc-validator.php`


------
https://chatgpt.com/codex/tasks/task_e_68a4317d43088331a65f693429827109