### PR TITLE
Fix currency symbol syntax errors in legacy shortcode

### DIFF
--- a/includes/legacy/class-qcc-shortcode-legacy.php
+++ b/includes/legacy/class-qcc-shortcode-legacy.php
@@ -1032,7 +1032,7 @@ class QCC_Shortcode {
     private function get_currency_symbol($currency) {
         $symbols = array(
             'EUR' => '€',
-            'USD' => ',
+            'USD' => '$',
             'CNY' => '¥'
         );
         return isset($symbols[$currency]) ? $symbols[$currency] : '€';
@@ -1688,7 +1688,7 @@ if (!function_exists('qcc_format_german_currency')) {
             case 'EUR':
                 return $formatted_amount . ' €';
             case 'USD':
-                return $formatted_amount . ' ;
+                return $formatted_amount . ' $';
             case 'CNY':
                 return $formatted_amount . ' ¥';
             default:


### PR DESCRIPTION
## Summary
- Correct USD symbol in legacy shortcode currency map
- Fix USD case in german currency formatting helper

## Testing
- `php -l includes/legacy/class-qcc-shortcode-legacy.php`

------
https://chatgpt.com/codex/tasks/task_e_68a43dbd3d0883318fdf316391000559