### PR TITLE
Fix bootstrap initialization method

### DIFF
--- a/includes/core/class-qcc-plugin.php
+++ b/includes/core/class-qcc-plugin.php
@@ -34,6 +34,6 @@ class QCC_Plugin {
     }
     
     public function init() {
-        QCC_Bootstrap::init();
+        QCC_Bootstrap::initialize();
     }
 }

--- a/quality-cost-calculator.php
+++ b/quality-cost-calculator.php
@@ -70,7 +70,7 @@ function qcc_init_plugin() {
         
         // Load bootstrap class
         if (class_exists('QCC_Bootstrap')) {
-            QCC_Bootstrap::init();
+            QCC_Bootstrap::initialize();
         } else {
             // Fallback to legacy system
             qcc_init_legacy_system();


### PR DESCRIPTION
## Summary
- ensure plugin bootstrap uses correct initialization method
- adjust plugin wrapper to call `QCC_Bootstrap::initialize()`

## Testing
- `php -l quality-cost-calculator.php`
- `php -l includes/core/class-qcc-plugin.php`


------
https://chatgpt.com/codex/tasks/task_e_68a455ae3e308331a42f64ad58130711